### PR TITLE
Bind Public Methods Implicitly

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,12 +36,22 @@ If you need more details about ENERTALK API client, see the [document](https://g
 
 ### Execute the 'calculate' method with setting
 - `siteHash` is required
+- The `calculate` method will return a promise
 
 ```js
 instance.calculate({
   siteHash: 'yourSiteHash',
   baseTime: Date.now(), // optional
   timezone: 'US/Pacific', // optional
+}).then((result) => {
+  const {
+    start,  // start timestamp of usage items
+    end, // end timestamp of usage items
+    period, // '15min'
+    usage,  // calculated 'always on' usage in milli watt
+  } = result;
+}).catch((error) => {
+  // Handle errors
 });
 ```
 

--- a/index.js
+++ b/index.js
@@ -169,6 +169,9 @@ class AlwaysOnCalculator {
     this.apiClient = AlwaysOnCalculator.getInstance(option);
     this.filters = [];
     this.setFilters(AlwaysOnCalculator.minimumDailyUsageFilter);
+
+    this.setFilters = this.setFilters.bind(this);
+    this.calculate = this.calculate.bind(this);
   }
 
   /*

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "enertalk-alwayson-calculator",
-  "version": "0.2.2",
+  "version": "0.2.3",
   "main": "index.js",
   "license": "MIT",
   "dependencies": {


### PR DESCRIPTION
### Issue
The public method(used from outside) in calculator may not bind to `this` normally.

### Changes
- Bind public methods to calculator instance implicitly
- Update doc